### PR TITLE
fix(ci): pin bash in the container job and unquote the pin allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,11 @@ jobs:
       # Must be explicit: the reusable workflow defaults this to
       # ${{ github.repository_owner }}/ which is irish1986/ here, and would then
       # flag every irishlab-io reusable call as unpinned.
+      # No quotes: the value is passed through to the action verbatim, and a
+      # block scalar preserves them as literal characters -- the entry would be
+      # `"irishlab-io/"` and match nothing.
       allowlist: |
-        "irishlab-io/"
+        irishlab-io/
 
   # Tier 0: structural checks ansible-lint cannot make. Seconds, no network.
   structure:
@@ -119,6 +122,13 @@ jobs:
     container:
       image: ubuntu:${{ matrix.release }}
       options: --user root
+
+    # Explicit: inside a container the runner picks the image's default shell,
+    # which is sh on some Ubuntu base images. `set -o pipefail` is a bashism and
+    # fails on line 1 there.
+    defaults:
+      run:
+        shell: bash
 
     env:
       DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
## Description of the change

Two bugs in `ci.yml`, both found by its own first real run on #153. The workflow was written but had never executed until that PR was open, so neither could have been caught earlier.

### Converge jobs died on line 1

```
/__w/_temp/....sh: 1: set: Illegal option -o pipefail
```

Inside a `container:`, the runner uses the **image's** default shell. That resolved to `sh` on the 22.04 and 24.04 base images — though, interestingly, not on 26.04, which is why that leg got as far as installing packages before failing. `set -o pipefail` is a bashism, so every `run:` block failed immediately:

| Job | Before |
|---|---|
| Converge (22.04) | fail in 4s |
| Converge (24.04) | fail in 6s |
| Converge (26.04) | fail in 55s |

Now pins bash explicitly rather than depending on what the image happens to ship.

### Pinned-actions flagged the allowlisted owner

```
##[error]irishlab-io/.github/.github/workflows/reusable-secret.yml@main is not pinned to a full length commit SHA.
```

…despite the allowlist naming exactly that owner. The value is passed through to `zgosalvez/github-actions-ensure-sha-pinned-actions` verbatim, and a block scalar preserves quotes as **literal characters** — so the entry was `"irishlab-io/"`, quotes included, and matched nothing.

```diff
   allowlist: |
-    "irishlab-io/"
+    irishlab-io/
```

The org's `reusable-gh-pin-actions.yml` has the same quoting in its `default:`, which is where the value was copied from — worth fixing upstream too, since anyone relying on the default hits this.

## Benefits

`ci.yml` on `main` currently fails these jobs on every run. This makes the converge matrix and the pin check actually work, which matters before `CI OK` becomes a required status check.

## Possible drawbacks

None. The converge jobs have never passed, so nothing regresses; they either start working or reveal the next real failure.

## Additional information

`ci.yml` parses as valid YAML, and every `uses:` job was re-checked for keys not permitted on reusable-workflow calls.

The remaining red jobs on `main` are known and unrelated to this:

- **Secret Scanning** — `GITGUARDIAN_API_KEY` is invalid and needs rotating.
- **Release** — `RELEASE_TOKEN` does not exist yet.
- **Docs / Deploy** — Settings → Pages → Source is not yet set to GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)